### PR TITLE
Revert Slevomat MissingNativeTypeHint sniffs

### DIFF
--- a/lib/Solido/ruleset.xml
+++ b/lib/Solido/ruleset.xml
@@ -13,9 +13,6 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
         <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
         <exclude name="Generic.Formatting.MultipleStatementAlignment" />
     </rule>


### PR DESCRIPTION
This will re-introduce Slevomat `MissingNativeTypeHint` sniffs ([reference](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintsparametertypehint-)).

Solido, as a best-practice coding standard setup, should try to enforce this checks. These can always be disabled on a project specific base, if needed. For future reference, on the `ruleset` definition file:
```xml
<?xml version="1.0"?>
<ruleset>
    [...]
    <rule ref="Solido">
        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
   </rule>
</ruleset>
```
